### PR TITLE
chore: tighten types

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -4,15 +4,27 @@ import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 
-export async function signIn(prevState: any, formData: FormData) {
+interface AuthActionState {
+  error?: string
+  success?: boolean | string
+}
+
+interface AuthFormData {
+  email: string
+  password: string
+}
+
+export async function signIn(
+  _prevState: AuthActionState,
+  formData: FormData,
+): Promise<AuthActionState> {
   console.log("[v0] SignIn action called")
 
   if (!formData) {
     return { error: "Form data is missing" }
   }
 
-  const email = formData.get("email")
-  const password = formData.get("password")
+  const { email, password } = Object.fromEntries(formData) as Partial<AuthFormData>
 
   if (!email || !password) {
     return { error: "Email and password are required" }
@@ -42,15 +54,17 @@ export async function signIn(prevState: any, formData: FormData) {
   }
 }
 
-export async function signUp(prevState: any, formData: FormData) {
+export async function signUp(
+  _prevState: AuthActionState,
+  formData: FormData,
+): Promise<AuthActionState> {
   console.log("[v0] SignUp action called")
 
   if (!formData) {
     return { error: "Form data is missing" }
   }
 
-  const email = formData.get("email")
-  const password = formData.get("password")
+  const { email, password } = Object.fromEntries(formData) as Partial<AuthFormData>
 
   if (!email || !password) {
     return { error: "Email and password are required" }

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -54,7 +54,11 @@ interface Question {
   type: string
   prompt: string
   correct_answer?: string
-  rubric_json?: any
+  rubric_json?: Rubric
+}
+
+interface Rubric {
+  points?: number
 }
 
 export async function gradeAnswer(question: Question, answer: string) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,6 +1,6 @@
-import { createClient } from "@supabase/supabase-js"
+import { createClient, SupabaseClient } from "@supabase/supabase-js"
 
-let supabase: any
+let supabase: SupabaseClient
 
 // Check if we're in a browser environment
 if (typeof window !== "undefined") {
@@ -14,7 +14,9 @@ if (typeof window !== "undefined") {
     supabase = {
       from: () => ({
         select: () => ({
-          eq: () => ({ single: () => Promise.resolve({ data: null, error: new Error("Supabase not configured") }) }),
+          eq: () => ({
+            single: () => Promise.resolve({ data: null, error: new Error("Supabase not configured") }),
+          }),
         }),
         insert: () => ({
           select: () => ({
@@ -22,7 +24,7 @@ if (typeof window !== "undefined") {
           }),
         }),
       }),
-    }
+    } as unknown as SupabaseClient
   } else {
     supabase = createClient(supabaseUrl, supabaseKey)
   }
@@ -37,7 +39,9 @@ if (typeof window !== "undefined") {
     supabase = {
       from: () => ({
         select: () => ({
-          eq: () => ({ single: () => Promise.resolve({ data: null, error: new Error("Supabase not configured") }) }),
+          eq: () => ({
+            single: () => Promise.resolve({ data: null, error: new Error("Supabase not configured") }),
+          }),
         }),
         insert: () => ({
           select: () => ({
@@ -45,7 +49,7 @@ if (typeof window !== "undefined") {
           }),
         }),
       }),
-    }
+    } as unknown as SupabaseClient
   } else {
     supabase = createClient(supabaseUrl, supabaseKey)
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "ES6",
     "skipLibCheck": true,
     "strict": true,
+    "noImplicitAny": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- add state and form interfaces for auth server actions
- type AI question rubrics
- use SupabaseClient type for db helper and enable noImplicitAny

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1)*


------
https://chatgpt.com/codex/tasks/task_e_68a1de5f4e3883319e72e8570a47291e