### PR TITLE
feat: centralize logging and sanitize sensitive data

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -3,6 +3,7 @@
 import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
+import { logger, maskEmail } from "@/lib/logger"
 
 interface AuthActionState {
   error?: string
@@ -18,7 +19,7 @@ export async function signIn(
   _prevState: AuthActionState,
   formData: FormData,
 ): Promise<AuthActionState> {
-  console.log("[v0] SignIn action called")
+  logger.debug("[v0] SignIn action called")
 
   if (!formData) {
     return { error: "Form data is missing" }
@@ -34,7 +35,7 @@ export async function signIn(
   const supabase = createServerActionClient({ cookies: () => cookieStore })
 
   try {
-    console.log("[v0] Attempting to sign in user:", email)
+    logger.debug({ email: maskEmail(email.toString()) }, "[v0] Attempting to sign in user")
 
     const { error } = await supabase.auth.signInWithPassword({
       email: email.toString(),
@@ -42,14 +43,14 @@ export async function signIn(
     })
 
     if (error) {
-      console.log("[v0] Sign in error:", error.message)
+      logger.error({ err: error }, "[v0] Sign in error")
       return { error: error.message }
     }
 
-    console.log("[v0] Sign in successful")
+    logger.info("[v0] Sign in successful")
     return { success: true }
   } catch (error) {
-    console.error("[v0] Login error:", error)
+    logger.error({ err: error }, "[v0] Login error")
     return { error: "An unexpected error occurred. Please try again." }
   }
 }
@@ -58,7 +59,7 @@ export async function signUp(
   _prevState: AuthActionState,
   formData: FormData,
 ): Promise<AuthActionState> {
-  console.log("[v0] SignUp action called")
+  logger.debug("[v0] SignUp action called")
 
   if (!formData) {
     return { error: "Form data is missing" }
@@ -74,7 +75,7 @@ export async function signUp(
   const supabase = createServerActionClient({ cookies: () => cookieStore })
 
   try {
-    console.log("[v0] Attempting to sign up user:", email)
+    logger.debug({ email: maskEmail(email.toString()) }, "[v0] Attempting to sign up user")
 
     const { error } = await supabase.auth.signUp({
       email: email.toString(),
@@ -86,14 +87,14 @@ export async function signUp(
     })
 
     if (error) {
-      console.log("[v0] Sign up error:", error.message)
+      logger.error({ err: error }, "[v0] Sign up error")
       return { error: error.message }
     }
 
-    console.log("[v0] Sign up successful")
+    logger.info("[v0] Sign up successful")
     return { success: "Check your email to confirm your account." }
   } catch (error) {
-    console.error("[v0] Sign up error:", error)
+    logger.error({ err: error }, "[v0] Sign up error")
     return { error: "An unexpected error occurred. Please try again." }
   }
 }

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/lib/logger"
+
 interface ConversationMessage {
   role: "system" | "user" | "assistant"
   content: string
@@ -41,7 +43,7 @@ export async function generateAIResponse(
       tokensUsed: Math.floor(Math.random() * 100) + 50,
     }
   } catch (error) {
-    console.error("Error generating AI response:", error)
+    logger.error({ err: error }, "Error generating AI response")
     return {
       content: "Извините, произошла техническая ошибка. Попробуйте задать вопрос еще раз.",
       tokensUsed: 0,
@@ -106,7 +108,7 @@ export async function gradeAnswer(question: Question, answer: string) {
       suggestions,
     }
   } catch (error) {
-    console.error("Error grading answer:", error)
+    logger.error({ err: error }, "Error grading answer")
     return {
       score: 0,
       feedback: "Произошла ошибка при проверке ответа. Попробуйте еще раз.",

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
+import { logger } from "@/lib/logger"
 
 export interface User {
   id: string
@@ -41,7 +42,7 @@ export async function getUser(): Promise<User | null> {
       avatar_url: profile.avatar_url,
     }
   } catch (error) {
-    console.error("Error getting user:", error)
+    logger.error({ err: error }, "Error getting user")
     return null
   }
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js"
+import { logger } from "@/lib/logger"
 
 let supabase: SupabaseClient
 
@@ -9,7 +10,7 @@ if (typeof window !== "undefined") {
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
   if (!supabaseUrl || !supabaseKey) {
-    console.error("[v0] Missing Supabase configuration for client")
+    logger.error("[v0] Missing Supabase configuration for client")
     // Don't use process.exit in browser - just create a dummy client
     supabase = {
       from: () => ({
@@ -34,7 +35,7 @@ if (typeof window !== "undefined") {
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!supabaseUrl || !supabaseKey) {
-    console.error("[v0] Missing Supabase configuration for server")
+    logger.error("[v0] Missing Supabase configuration for server")
     // Create a dummy client for server-side when not configured
     supabase = {
       from: () => ({
@@ -56,7 +57,7 @@ if (typeof window !== "undefined") {
 }
 
 export async function query(text: string, params?: any[]) {
-  console.log("[v0] Raw SQL query not supported with Supabase:", text)
+  logger.warn({ text }, "[v0] Raw SQL query not supported with Supabase")
   return { rows: [] }
 }
 
@@ -68,7 +69,7 @@ export async function getUser(email: string) {
     .single()
 
   if (error) {
-    console.log("[v0] Error fetching user:", error)
+    logger.error({ err: error }, "[v0] Error fetching user")
     return null
   }
   return data
@@ -82,7 +83,7 @@ export async function createUser(email: string, name: string, passwordHash: stri
     .single()
 
   if (error) {
-    console.log("[v0] Error creating user:", error)
+    logger.error({ err: error }, "[v0] Error creating user")
     throw error
   }
   return data
@@ -97,14 +98,14 @@ export async function getCourses(limit = 20, offset = 0) {
     .range(offset, offset + limit - 1)
 
   if (error) {
-    console.log("[v0] Error fetching courses:", error)
+    logger.error({ err: error }, "[v0] Error fetching courses")
     return []
   }
   return data || []
 }
 
 export async function getCourse(slug: string) {
-  console.log("[v0] Fetching course with slug:", slug)
+  logger.debug({ slug }, "[v0] Fetching course with slug")
 
   const { data, error } = await supabase
     .from("courses")
@@ -114,11 +115,11 @@ export async function getCourse(slug: string) {
     .maybeSingle()
 
   if (error) {
-    console.log("[v0] Error fetching course:", error)
+    logger.error({ err: error }, "[v0] Error fetching course")
     return null
   }
 
-  console.log("[v0] Course data:", data)
+  logger.debug({ data }, "[v0] Course data")
   return data
 }
 
@@ -130,7 +131,7 @@ export async function getLessons(courseId: string) {
     .order("order_index", { ascending: true })
 
   if (error) {
-    console.log("[v0] Error fetching lessons:", error)
+    logger.error({ err: error }, "[v0] Error fetching lessons")
     return []
   }
   return data || []
@@ -173,7 +174,7 @@ export async function getRevenueAnalytics() {
     .order("created_at")
 
   if (error) {
-    console.log("[v0] Error fetching revenue analytics:", error)
+    logger.error({ err: error }, "[v0] Error fetching revenue analytics")
     return []
   }
 
@@ -203,7 +204,7 @@ export async function getUserGrowthAnalytics() {
     .order("created_at")
 
   if (error) {
-    console.log("[v0] Error fetching user growth:", error)
+    logger.error({ err: error }, "[v0] Error fetching user growth")
     return []
   }
 
@@ -224,7 +225,7 @@ export async function getCoursePerformanceAnalytics() {
   const { data: courses, error: coursesError } = await supabase.from("courses").select("id, title").limit(10)
 
   if (coursesError) {
-    console.log("[v0] Error fetching course performance:", coursesError)
+    logger.error({ err: coursesError }, "[v0] Error fetching course performance")
     return []
   }
 
@@ -258,7 +259,7 @@ export async function getChatAnalytics() {
     .order("created_at")
 
   if (error) {
-    console.log("[v0] Error fetching chat analytics:", error)
+    logger.error({ err: error }, "[v0] Error fetching chat analytics")
     return []
   }
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,32 @@
+import pino from 'pino';
+
+const level = process.env.LOG_LEVEL || (process.env.NODE_ENV === 'production' ? 'info' : 'debug');
+
+export const logger = pino({
+  level,
+  redact: {
+    paths: ['email', '*.email', 'token', '*.token', 'password', '*.password', 'authorization', '*.authorization'],
+    censor: '[REDACTED]'
+  }
+});
+
+export function maskEmail(email: string): string {
+  const [user, domain] = email.split('@');
+  if (!user || !domain) return '[REDACTED]';
+  return `${user[0]}***@${domain}`;
+}
+
+export function sanitize<T>(obj: T): T {
+  if (!obj || typeof obj !== 'object') return obj;
+  const clone: any = Array.isArray(obj) ? [] : {};
+  for (const [key, value] of Object.entries(obj as any)) {
+    if (/email|token|password/i.test(key)) {
+      clone[key] = '[REDACTED]';
+    } else if (typeof value === 'object') {
+      clone[key] = sanitize(value);
+    } else {
+      clone[key] = value;
+    }
+  }
+  return clone as T;
+}

--- a/lib/payments.ts
+++ b/lib/payments.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/lib/logger"
+
 interface CheckoutParams {
   orderId: string
   amount: number
@@ -65,7 +67,7 @@ export async function createYooKassaPayment({
 
   if (!response.ok) {
     const errorText = await response.text()
-    console.error("YooKassa API error:", errorText)
+    logger.error({ err: errorText }, "YooKassa API error")
     throw new Error("Failed to create YooKassa payment")
   }
 

--- a/lib/speech.ts
+++ b/lib/speech.ts
@@ -1,3 +1,5 @@
+import { logger } from "@/lib/logger"
+
 export async function transcribeAudio(audioUrl: string): Promise<string> {
   // Simulate transcription delay
   await new Promise((resolve) => setTimeout(resolve, 2000))
@@ -14,7 +16,7 @@ export async function transcribeAudio(audioUrl: string): Promise<string> {
 
     return mockTranscriptions[Math.floor(Math.random() * mockTranscriptions.length)]
   } catch (error) {
-    console.error("Error transcribing audio:", error)
+    logger.error({ err: error }, "Error transcribing audio")
     throw new Error("Failed to transcribe audio")
   }
 }
@@ -26,12 +28,12 @@ export async function generateSpeech(text: string, voice = "nova"): Promise<stri
   try {
     // For demo purposes, return a placeholder audio URL
     // In a real implementation, this would generate actual speech
-    console.log(`[Mock] Generating speech for: "${text}" with voice: ${voice}`)
+    logger.debug({ voice }, `[Mock] Generating speech`)
 
     // Return a placeholder audio file URL (you could use a real audio file here)
     return "/placeholder-audio.mp3"
   } catch (error) {
-    console.error("Error generating speech:", error)
+    logger.error({ err: error }, "Error generating speech")
     throw new Error("Failed to generate speech")
   }
 }

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,4 +1,5 @@
 import { createClientComponentClient } from "@supabase/auth-helpers-nextjs"
+import { logger } from "@/lib/logger"
 
 // Check if Supabase environment variables are available
 export const isSupabaseConfigured =
@@ -9,7 +10,7 @@ export const isSupabaseConfigured =
 
 export function createClient() {
   if (!isSupabaseConfigured) {
-    console.error("[v0] Supabase environment variables are not configured properly")
+    logger.error("[v0] Supabase environment variables are not configured properly")
     throw new Error("Supabase is not configured. Please check your environment variables.")
   }
 
@@ -19,7 +20,7 @@ export function createClient() {
       supabaseKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     })
   } catch (error) {
-    console.error("[v0] Error creating Supabase client:", error)
+    logger.error({ err: error }, "[v0] Error creating Supabase client")
     throw error
   }
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,6 +1,7 @@
 import { createServerComponentClient } from "@supabase/auth-helpers-nextjs"
 import { cookies } from "next/headers"
 import { cache } from "react"
+import { logger } from "@/lib/logger"
 
 // Check if Supabase environment variables are available
 export const isSupabaseConfigured =
@@ -14,7 +15,7 @@ export const createClient = cache(() => {
   const cookieStore = cookies()
 
   if (!isSupabaseConfigured) {
-    console.warn("Supabase environment variables are not set. Using dummy client.")
+    logger.warn("Supabase environment variables are not set. Using dummy client.")
     return {
       auth: {
         getUser: () => Promise.resolve({ data: { user: null }, error: null }),

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lucide-react": "^0.454.0",
     "next": "14.2.16",
     "next-themes": "latest",
+    "pino": "^8.16.0",
     "react": "^18",
     "react-day-picker": "9.8.0",
     "react-dom": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       next-themes:
         specifier: latest
         version: 0.4.6(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      pino:
+        specifier: ^8.16.0
+        version: 8.21.0
       react:
         specifier: ^18
         version: 18.0.0
@@ -1611,6 +1614,10 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
@@ -1657,6 +1664,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   autoprefixer@10.4.20:
     resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1666,6 +1677,9 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1682,6 +1696,9 @@ packages:
     resolution: {integrity: sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1878,8 +1895,16 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
@@ -1888,6 +1913,10 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1947,6 +1976,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
@@ -2102,6 +2134,10 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -2137,6 +2173,16 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+
+  pino-abstract-transport@1.2.0:
+    resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
+
+  pino-std-serializers@6.2.2:
+    resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
+
+  pino@8.21.0:
+    resolution: {integrity: sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==}
+    hasBin: true
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -2191,8 +2237,18 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  process-warning@3.0.0:
+    resolution: {integrity: sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   react-day-picker@9.8.0:
     resolution: {integrity: sha512-E0yhhg7R+pdgbl/2toTb0xBhsEAtmAx1l7qjIWYfcxOy8w4rTSVfbtBoSzVVhPwKP/5E9iL38LivzoE3AQDhCQ==}
@@ -2269,9 +2325,17 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   recharts@3.1.2:
     resolution: {integrity: sha512-vhNbYwaxNbk/IATK0Ki29k3qvTkGqwvCgyQAQ9MavvvBwjvKnMTswdbklJpcOAoMPN/qxF3Lyqob0zO+ZXkZ4g==}
@@ -2309,6 +2373,13 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   scheduler@0.21.0:
     resolution: {integrity: sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==}
 
@@ -2330,6 +2401,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sonic-boom@3.8.1:
+    resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
+
   sonner@1.7.1:
     resolution: {integrity: sha512-b6LHBfH32SoVasRFECrdY8p8s7hXPDn3OHUFbZZbiB1ctLS9Gdh6rpX2dVrpQA0kiL5jcRzDDldwwLkSKk3+QQ==}
     peerDependencies:
@@ -2339,6 +2413,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2357,6 +2435,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2410,6 +2491,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@2.7.0:
+    resolution: {integrity: sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3961,6 +4045,10 @@ snapshots:
       loupe: 3.2.0
       tinyrainbow: 2.0.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
@@ -3994,6 +4082,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  atomic-sleep@1.0.0: {}
+
   autoprefixer@10.4.20(postcss@8.5.0):
     dependencies:
       browserslist: 4.25.2
@@ -4005,6 +4095,8 @@ snapshots:
       postcss-value-parser: 4.2.0
 
   balanced-match@1.0.2: {}
+
+  base64-js@1.5.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -4022,6 +4114,11 @@ snapshots:
       electron-to-chromium: 1.5.202
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.2)
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   busboy@1.6.0:
     dependencies:
@@ -4214,7 +4311,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@5.0.1: {}
+
+  events@3.3.0: {}
 
   expect-type@1.2.2: {}
 
@@ -4225,6 +4326,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-redact@3.5.0: {}
 
   fastq@1.19.1:
     dependencies:
@@ -4278,6 +4381,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  ieee754@1.2.1: {}
 
   immer@10.1.1: {}
 
@@ -4408,6 +4513,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   package-json-from-dist@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -4430,6 +4537,27 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@2.3.0: {}
+
+  pino-abstract-transport@1.2.0:
+    dependencies:
+      readable-stream: 4.7.0
+      split2: 4.2.0
+
+  pino-std-serializers@6.2.2: {}
+
+  pino@8.21.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.2.0
+      pino-std-serializers: 6.2.2
+      process-warning: 3.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 3.8.1
+      thread-stream: 2.7.0
 
   pirates@4.0.7: {}
 
@@ -4483,7 +4611,13 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  process-warning@3.0.0: {}
+
+  process@0.11.10: {}
+
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   react-day-picker@9.8.0(react@18.0.0):
     dependencies:
@@ -4553,9 +4687,19 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  real-require@0.2.0: {}
 
   recharts@3.1.2(@types/react@18.0.0)(react-dom@18.0.0(react@18.0.0))(react-is@19.1.1)(react@18.0.0)(redux@5.0.1):
     dependencies:
@@ -4623,6 +4767,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
+
   scheduler@0.21.0:
     dependencies:
       loose-envify: 1.4.0
@@ -4639,12 +4787,18 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sonic-boom@3.8.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   sonner@1.7.1(react-dom@18.0.0(react@18.0.0))(react@18.0.0):
     dependencies:
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
 
   source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
@@ -4663,6 +4817,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4733,6 +4891,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@2.7.0:
+    dependencies:
+      real-require: 0.2.0
 
   tiny-invariant@1.3.3: {}
 


### PR DESCRIPTION
## Summary
- add a shared pino logger with configurable levels and redaction for emails, tokens, and passwords
- replace console calls in lib with logger usage, masking emails where logged
- suppress debug logs in production for cleaner output

## Testing
- `pnpm test`
- `pnpm lint` *(fails: If you set up ESLint yourself, we recommend adding the Next.js ESLint plugin)*


------
https://chatgpt.com/codex/tasks/task_e_68a1e1a5ba608331b9d2f60cfff2e6cc