### PR TITLE
Document OpenAI environment variables and secure loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Database
+DATABASE_URL=postgresql://postgres:password@postgres:5432/aischool
+POSTGRES_PASSWORD=your_secure_password
+
+# Authentication
+JWT_SECRET=your_jwt_secret_key_min_32_chars
+
+# Payment Processing
+YOOKASSA_SECRET_KEY=your_yookassa_secret_key
+YOOKASSA_SHOP_ID=your_yookassa_shop_id
+YOOKASSA_WEBHOOK_SECRET=your_webhook_secret
+
+# Application
+NEXT_PUBLIC_APP_URL=https://your-domain.com
+NODE_ENV=production
+# Optional: enable seed endpoint
+# ENABLE_SEED_COURSE=true
+
+# OpenAI API configuration
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_API_BASE_URL=https://api.openai.com/v1
+OPENAI_TTS_MODEL=gpt-4o-mini-tts
+OPENAI_TTS_VOICE=nova
+# Exposed to client
+NEXT_PUBLIC_OPENAI_TTS_MODEL=gpt-4o-mini-tts
+NEXT_PUBLIC_OPENAI_TTS_VOICE=nova

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log*
 
 # env files
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -32,6 +32,11 @@ NODE_ENV=production
 
 # Optional: AI Integration
 OPENAI_API_KEY=your_openai_api_key
+OPENAI_API_BASE_URL=https://api.openai.com/v1
+OPENAI_TTS_MODEL=gpt-4o-mini-tts
+OPENAI_TTS_VOICE=nova
+NEXT_PUBLIC_OPENAI_TTS_MODEL=gpt-4o-mini-tts
+NEXT_PUBLIC_OPENAI_TTS_VOICE=nova
 \`\`\`
 
 ## Deployment Steps
@@ -47,6 +52,7 @@ OPENAI_API_KEY=your_openai_api_key
    cp .env.example .env.production
    # Edit .env.production with your values
    \`\`\`
+   Docker Compose loads this file via `env_file`, keeping secrets out of version control.
 
 3. **Setup SSL certificates:**
    \`\`\`bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,12 @@ version: '3.8'
 services:
   app:
     build: .
-    ports:
-      - "3000:3000"
+    env_file:
+      - .env.production
     environment:
       - NODE_ENV=production
-      - DATABASE_URL=${DATABASE_URL}
-      - JWT_SECRET=${JWT_SECRET}
-      - YOOKASSA_SECRET_KEY=${YOOKASSA_SECRET_KEY}
-      - YOOKASSA_SHOP_ID=${YOOKASSA_SHOP_ID}
-      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
+    ports:
+      - "3000:3000"
     depends_on:
       - postgres
       - redis
@@ -19,10 +16,11 @@ services:
 
   postgres:
     image: postgres:15-alpine
+    env_file:
+      - .env.production
     environment:
       - POSTGRES_DB=aischool
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts:/docker-entrypoint-initdb.d

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,14 @@
+const isServer = typeof window === 'undefined'
+
+export const OPENAI_API_KEY = isServer
+  ? process.env.OPENAI_API_KEY
+  : undefined
+
+export const OPENAI_API_BASE_URL =
+  process.env.OPENAI_API_BASE_URL ?? 'https://api.openai.com/v1'
+
+export const OPENAI_TTS_MODEL =
+  process.env.NEXT_PUBLIC_OPENAI_TTS_MODEL ?? process.env.OPENAI_TTS_MODEL ?? 'gpt-4o-mini-tts'
+
+export const OPENAI_TTS_VOICE =
+  process.env.NEXT_PUBLIC_OPENAI_TTS_VOICE ?? process.env.OPENAI_TTS_VOICE ?? 'nova'

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,10 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  env: {
+    NEXT_PUBLIC_OPENAI_TTS_MODEL: process.env.NEXT_PUBLIC_OPENAI_TTS_MODEL,
+    NEXT_PUBLIC_OPENAI_TTS_VOICE: process.env.NEXT_PUBLIC_OPENAI_TTS_VOICE,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- add `.env.example` and document OpenAI-related variables
- centralize env access in `lib/config.ts` and expose model to client via Next config
- load secrets from `.env.production` using Docker Compose
- expose OpenAI TTS voice via `NEXT_PUBLIC_OPENAI_TTS_VOICE`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e927ff648331a2b054cec5532b1c