### PR TITLE
Replace alerts with toast notifications in lesson page

### DIFF
--- a/app/courses/[slug]/lessons/[lessonId]/page.tsx
+++ b/app/courses/[slug]/lessons/[lessonId]/page.tsx
@@ -23,6 +23,7 @@ import { notFound } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
 import Link from "next/link"
 import { useState, useEffect, useRef } from "react"
+import { toast } from "sonner"
 
 const supabase = createClient()
 
@@ -178,7 +179,7 @@ export default function LessonPage({
 
       setTimeout(() => {
         const score = Math.floor(Math.random() * 20) + 80 // 80-100%
-        alert(
+        toast.success(
           `Запись завершена! Ваше произношение оценено на ${score}%. ${score >= 90 ? "Отлично!" : score >= 80 ? "Хорошо!" : "Продолжайте практиковаться!"}`,
         )
       }, 500)
@@ -218,7 +219,7 @@ export default function LessonPage({
         ? "Отличный развернутый ответ! AI преподаватель оценил ваше понимание материала."
         : "Хороший ответ! Попробуйте добавить больше деталей в следующий раз."
 
-    alert(`Упражнение отправлено! ${feedback}`)
+    toast.success(`Упражнение отправлено! ${feedback}`)
     setExerciseAnswer("")
     setCurrentExercise(getExerciseQuestion(lesson?.title || ""))
   }


### PR DESCRIPTION
## Summary
- use design-system toast notifications instead of `alert` in lesson page
- add success feedback for voice recording and exercise submissions

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Command failed with exit code 1 due to interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fa47fe0c833197eaa01417b9c265